### PR TITLE
Bubble synthetic event so more websites can catch them

### DIFF
--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -164,6 +164,7 @@ class GhostTextField {
 				this.field.dispatchEvent(new KeyboardEvent('keypress'));
 				this.field.dispatchEvent(new CompositionEvent('textInput'));
 				this.field.dispatchEvent(new CustomEvent('input', { // InputEvent doesn't support custom data
+					bubbles: true,
 					detail: {
 						ghostTextSyntheticEvent: true
 					}

--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -3,6 +3,7 @@ import unsafeMessenger from './unsafe-messenger.js';
 
 const knownElements = new Map();
 const activeFields = new Set();
+const eventOptions = { bubbles: true };
 
 let isWaitingForActivation = false;
 const startTimeout = 15000;
@@ -160,16 +161,16 @@ class GhostTextField {
 
 			if (this.field.dispatchEvent) {
 				// These are in the right order
-				this.field.dispatchEvent(new KeyboardEvent('keydown'));
-				this.field.dispatchEvent(new KeyboardEvent('keypress'));
-				this.field.dispatchEvent(new CompositionEvent('textInput'));
+				this.field.dispatchEvent(new KeyboardEvent('keydown'), eventOptions);
+				this.field.dispatchEvent(new KeyboardEvent('keypress'), eventOptions);
+				this.field.dispatchEvent(new CompositionEvent('textInput'), eventOptions);
 				this.field.dispatchEvent(new CustomEvent('input', { // InputEvent doesn't support custom data
-					bubbles: true,
+					...eventOptions,
 					detail: {
 						ghostTextSyntheticEvent: true
 					}
 				}));
-				this.field.dispatchEvent(new KeyboardEvent('keyup'));
+				this.field.dispatchEvent(new KeyboardEvent('keyup'), eventOptions);
 			}
 		}
 

--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -3,7 +3,7 @@ import unsafeMessenger from './unsafe-messenger.js';
 
 const knownElements = new Map();
 const activeFields = new Set();
-const eventOptions = { bubbles: true };
+const eventOptions = {bubbles: true};
 
 let isWaitingForActivation = false;
 const startTimeout = 15000;


### PR DESCRIPTION
There are some client-side JavaScript frameworks like React or Ember that without the `bubbles: true` option in the input event don't trigger its own `onChange` events when the input changes.

Two examples are of websites that don't work without this option are the email editor of [frontapp.com](https://frontapp.com/) and the post editor of all the [Discourse](https://www.discourse.org/) forums. I'm sure there will be many more 🙂 