### PR TITLE
Reduce vim plugin choice in readme discarding outdated ones

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,6 @@ Use your text editor to write in your browser. Everything you type in the editor
 			<summary><b>Vim</b>/<b>Neovim</b> (Third party)</summary>
 			<ul>
 				<li><a href="https://github.com/raghur/vim-ghost"><b>Vim</b> (<tt>+python3</tt>) & <b>Neovim</b> (<tt>pynvim</tt>)</a>
-				<li><a href="https://github.com/falstro/ghost-text-vim"><b>Vim</b> (<tt>+tcl</tt>)</a>
 				<li><a href="https://github.com/pandysong/ghost-text.vim"><b>Vim</b> (<tt>+python3 +channel</tt>)</a>
 				<li><a href="https://github.com/subnut/nvim-ghost.nvim"><b>Neovim</b></a>
 			</ul>

--- a/readme.md
+++ b/readme.md
@@ -15,14 +15,8 @@ Use your text editor to write in your browser. Everything you type in the editor
 	- [**VS Code**](https://marketplace.visualstudio.com/items?itemName=tokoph.ghosttext) ([Repo](https://github.com/jtokoph/ghosttext-vscode)) (Third party)
 	- [**Emacs**](https://melpa.org/#/atomic-chrome) ([Repo](https://github.com/alpha22jp/atomic-chrome)) (Third party)
 	- [**Acme**](https://github.com/fhs/Ghost) (Third party)
-	- <details>
-			<summary><b>Vim</b>/<b>Neovim</b> (Third party)</summary>
-			<ul>
-				<li><a href="https://github.com/raghur/vim-ghost"><b>Vim</b> (<tt>+python3</tt>) & <b>Neovim</b> (<tt>pynvim</tt>)</a>
-				<li><a href="https://github.com/pandysong/ghost-text.vim"><b>Vim</b> (<tt>+python3 +channel</tt>)</a>
-				<li><a href="https://github.com/subnut/nvim-ghost.nvim"><b>Neovim</b></a>
-			</ul>
-		</details>
+	- [**Vim**](https://github.com/raghur/vim-ghost) (Third party)
+	- [**Neovim**](https://github.com/subnut/nvim-ghost.nvim) (Third party)
 
 2. Install your browser extension:
 


### PR DESCRIPTION
- pandysong/ghost-text is still marked as "preliminary version" and the last update was in 2018
- falstro/ghost-text-vim doesn't work both ways and the last update was BC
- raghur/vim-ghost also works on Neovim, but for the sake of simplicity I'll keep it marked just as vim since there's a no-dependency neovim-only version