### PR TITLE
Support fields nested in CodeMirror widgets

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -28,9 +28,6 @@
 			textarea {
 				font: inherit;
 			}
-			.CodeMirror-linewidget textarea {
-				min-height: 1em;
-			}
 			.flex {
 				display: flex;
 				justify-content: space-between;
@@ -70,24 +67,8 @@
 </textarea>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.32.0/codemirror.min.js"></script>
 	<script>
-		const cm = window.CodeMirror.fromTextArea(document.getElementById('codemirror'), {
-			lineNumbers: true,
-                        gutters: ['CodeMirror-linenumbers'],
-		});
-		cm.on('gutterClick', (cm, line) => {
-			const info = cm.getLineHandle(line);
-			if (info.widgets) {
-				info.widgets.map(w => {
-					const node = w.node;
-					w.clear();
-					node.parentNode.removeChild(node);
-				});
-			} else {
-				const msg = document.createElement('textarea');
-				msg.select();
-				msg.setRangeText('This is a textarea as CodeMirror line widget');
-				cm.addLineWidget(line, msg, {coverGutter: false, noHScroll: true});
-			}
+		window.CodeMirror.fromTextArea(document.getElementById('codemirror'), {
+			lineNumbers: true
 		});
 	</script>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -28,6 +28,9 @@
 			textarea {
 				font: inherit;
 			}
+			.CodeMirror-linewidget textarea {
+				min-height: 1em;
+			}
 			.flex {
 				display: flex;
 				justify-content: space-between;
@@ -67,8 +70,24 @@
 </textarea>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.32.0/codemirror.min.js"></script>
 	<script>
-		window.CodeMirror.fromTextArea(document.getElementById('codemirror'), {
-			lineNumbers: true
+		const cm = window.CodeMirror.fromTextArea(document.getElementById('codemirror'), {
+			lineNumbers: true,
+                        gutters: ['CodeMirror-linenumbers'],
+		});
+		cm.on('gutterClick', (cm, line) => {
+			const info = cm.getLineHandle(line);
+			if (info.widgets) {
+				info.widgets.map(w => {
+					const node = w.node;
+					w.clear();
+					node.parentNode.removeChild(node);
+				});
+			} else {
+				const msg = document.createElement('textarea');
+				msg.select();
+				msg.setRangeText('This is a textarea as CodeMirror line widget');
+				cm.addLineWidget(line, msg, {coverGutter: false, noHScroll: true});
+			}
 		});
 	</script>
 

--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -73,13 +73,9 @@ function wrapField(field) {
 		return new AdvancedTextWrapper(ace, visualElement);
 	}
 
-	const cm = field.closest('.CodeMirror');
-	if (cm) {
-		const lw = field.closest('.CodeMirror-linewidget');
-		if (lw?.closest('.CodeMirror') === cm) {
-			return field;
-		}
-
+	// Stop at a linewidget to avoid connecting a nested field to the enclosing CodeMirror.
+	const cm = field.closest('.CodeMirror, .CodeMirror-linewidget');
+	if (cm && cm.matches('.CodeMirror')) {
 		const visualElement = cm.querySelector('.CodeMirror-sizer');
 		return new AdvancedTextWrapper(cm, visualElement);
 	}

--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -75,6 +75,11 @@ function wrapField(field) {
 
 	const cm = field.closest('.CodeMirror');
 	if (cm) {
+		const lw = field.closest('.CodeMirror-linewidget');
+		if (lw?.closest('.CodeMirror') === cm) {
+			return field;
+		}
+
 		const visualElement = cm.querySelector('.CodeMirror-sizer');
 		return new AdvancedTextWrapper(cm, visualElement);
 	}

--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -73,7 +73,7 @@ function wrapField(field) {
 		return new AdvancedTextWrapper(ace, visualElement);
 	}
 
-	// Stop at a linewidget to avoid connecting a nested field to the enclosing CodeMirror.
+	// If `field` is inside CodeMirror widget, it should be handled independently of it
 	const cm = field.closest('.CodeMirror, .CodeMirror-linewidget');
 	if (cm && cm.matches('.CodeMirror')) {
 		const visualElement = cm.querySelector('.CodeMirror-sizer');


### PR DESCRIPTION
Bitbucket Server pull requests use CodeMirror for code display and
textareas for line-comment widgets.

Check the field for an enclosing .CodeMirror-linewidget and skip the
CodeMirror hook-up when found. Without this change, editing a comment
instead pulls in the source code, and saving overwrites the markup on
the source. (Even with this change, editing the source itself wipes
out the widget.)

Extend the CodeMirror example in the demo so that clicking on a
linenumber toggles a textarea line widget into and out of existence.
The textarea as a widget reproduces the buggy behavior in the
version of the plugin before this commit.