### PR TITLE
Dispatch change event

### DIFF
--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -172,6 +172,7 @@ class GhostTextField {
 					}
 				}));
 				this.field.dispatchEvent(new KeyboardEvent('keyup'), eventOptions);
+				this.field.dispatchEvent(new Event('change', eventOptions));
 			}
 		}
 


### PR DESCRIPTION
GhostText was dispatching different events to simulate the user input, but not the `change` event. This PR adds it.

Fixes #213.