### PR TITLE
Dispatch events on `contentEditable` elements

### DIFF
--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -15,6 +15,7 @@ class ContentEditableWrapper {
 		this.dataset = element.dataset;
 		this.addEventListener = element.addEventListener.bind(element);
 		this.removeEventListener = element.removeEventListener.bind(element);
+		this.dispatchEvent = element.dispatchEvent.bind(element);
 		this.blur = element.blur.bind(element);
 	}
 


### PR DESCRIPTION
I was taking a look to see why [Notion](https://www.notion.so/) was not working properly and I noticed that for fields that are `contentEditable`, the events are not dispatched because the `contentEditable` wrapper doesn't have the `element.dispatchEvent` method bonded. Therefore, [this conditional](https://github.com/fregante/GhostText/blob/main/source/ghost-text.js#L163) is never run.

I wonder if that was on purpose or not. [Notion](https://www.notion.so/) seems to depend on the `input` event, so it woks fine after this modification.