### PR TITLE
Add support for Monaco Editor

### DIFF
--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -68,6 +68,12 @@ class AdvancedTextWrapper {
 }
 
 function wrapField(field) {
+	const monaco = field.closest('.monaco-editor, .editor-widget');
+	if (monaco && monaco.matches('.monaco-editor')) {
+		const visualElement = document.querySelector('.lines-content.monaco-editor-background');
+		return new AdvancedTextWrapper(monaco, visualElement);
+	}
+
 	if (field.classList.contains('ace_text-input')) {
 		const ace = field.parentNode;
 		const visualElement = ace.querySelector('.ace_scroller');

--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -68,9 +68,9 @@ class AdvancedTextWrapper {
 }
 
 function wrapField(field) {
-	const monaco = field.closest('.monaco-editor, .editor-widget');
-	if (monaco && monaco.matches('.monaco-editor')) {
-		const visualElement = document.querySelector('.lines-content.monaco-editor-background');
+	const monaco = field.closest('.monaco-editor');
+	if (monaco) {
+		const visualElement = monaco.querySelector('.monaco-editor-background');
 		return new AdvancedTextWrapper(monaco, visualElement);
 	}
 

--- a/source/unsafe-messenger.js
+++ b/source/unsafe-messenger.js
@@ -13,6 +13,7 @@ export default function unsafeMessenger() {
 			monacoEditor(target);
 		} else {
 			ace(target);
+		}
 	}
 
 	function sendBack(target, value) {

--- a/source/unsafe-messenger.js
+++ b/source/unsafe-messenger.js
@@ -78,25 +78,19 @@ export default function unsafeMessenger() {
 
 	function monacoEditor(target) {
 		const editor = globalThis.monaco.editor.getModel(target.dataset.uri);
-		const currentValue = editor.getValue();
-		sendBack(target, currentValue);
-		const throttledSend = throttle(50, sendBack);
+		sendBack(target, editor.getValue());
 
-		editor.onDidChangeContent(event => {
-			if (event.isUserChange && currentValue !== editor.getValue()) {
-				throttledSend(target, editor.getValue());
+		editor.onDidChangeContent(throttle(50, event => {
+			if (!event.isFlush) { // Flush === setValue
+				sendBack(target, editor.getValue());
 			}
-		});
+		}));
 
 		target.addEventListener('gt:transfer', () => {
 			editor.setValue(target.getAttribute('gt-value'));
 		});
 		target.addEventListener('gt:blur', () => {
-			if (editor.container.contentWindow) {
-				editor.container.contentWindow.document.activeElement.blur();
-			} else {
-				editor.container.document.activeElement.blur();
-			}
+			target.ownerDocument.activeElement.blur();
 		});
 	}
 }

--- a/source/unsafe-messenger.js
+++ b/source/unsafe-messenger.js
@@ -6,12 +6,14 @@
 export default function unsafeMessenger() {
 	document.body.addEventListener('gt:get', listener);
 
+	// Add a new condition to check for the existence of the monaco object
 	function listener({target}) {
 		if (target.CodeMirror) {
 			codeMirror(target);
+		} else if (monaco) {
+			monacoEditor(target);
 		} else {
 			ace(target);
-		}
 	}
 
 	function sendBack(target, value) {
@@ -71,6 +73,28 @@ export default function unsafeMessenger() {
 		});
 		target.addEventListener('gt:blur', () => {
 			editor.blur();
+		});
+	}
+
+	// Add a new function to handle the Monaco editor
+	function monacoEditor(target) {
+		const editor = monaco.editor.getModels()[0];
+
+		sendBack(target, editor.getValue());
+
+		editor.onDidChangeContent(() => {
+			sendBack(target, editor.getValue());
+		});
+		target.addEventListener('gt:transfer', () => {
+			editor.setValue(target.getAttribute('gt-value'));
+		});
+		target.addEventListener('gt:blur', () => {
+			// If the Monaco editor is in an iframe, you'll need to access it through the iframe's contentWindow
+			if (editor.container.contentWindow) {
+				editor.container.contentWindow.document.activeElement.blur();
+			} else {
+				editor.container.document.activeElement.blur();
+			}
 		});
 	}
 }

--- a/source/unsafe-messenger.js
+++ b/source/unsafe-messenger.js
@@ -77,7 +77,7 @@ export default function unsafeMessenger() {
 
 	function monacoEditor(target) {
 		const data_uri = target.getAttribute("data-uri");
-		const editor = monaco.editor.getModels(data_uri)[0];
+		const editor = monaco.editor.getModel(data_uri);
 		let currentValue = editor.getValue();
 		sendBack(target, currentValue);
 		const throttledSend = throttle(50, sendBack);

--- a/source/unsafe-messenger.js
+++ b/source/unsafe-messenger.js
@@ -76,20 +76,26 @@ export default function unsafeMessenger() {
 		});
 	}
 
-	// Add a new function to handle the Monaco editor
 	function monacoEditor(target) {
 		const editor = monaco.editor.getModels()[0];
+		let currentValue = editor.getValue();
+		sendBack(target, currentValue);
 
-		sendBack(target, editor.getValue());
-
-		editor.onDidChangeContent(() => {
-			sendBack(target, editor.getValue());
+		editor.onDidChangeContent((e) => {
+			// Check if the change was made by the user
+			if (e.isUserChange) {
+				// Check if the current value is different from the previous value
+				if (currentValue !== editor.getValue()) {
+					currentValue = editor.getValue();
+					throttle(50, sendBack)(target, currentValue);
+				}
+			}
 		});
+	
 		target.addEventListener('gt:transfer', () => {
 			editor.setValue(target.getAttribute('gt-value'));
 		});
 		target.addEventListener('gt:blur', () => {
-			// If the Monaco editor is in an iframe, you'll need to access it through the iframe's contentWindow
 			if (editor.container.contentWindow) {
 				editor.container.contentWindow.document.activeElement.blur();
 			} else {
@@ -97,6 +103,7 @@ export default function unsafeMessenger() {
 			}
 		});
 	}
+	
 }
 
 // eslint-disable-next-line no-unused-expressions

--- a/source/unsafe-messenger.js
+++ b/source/unsafe-messenger.js
@@ -9,7 +9,7 @@ export default function unsafeMessenger() {
 	function listener({target}) {
 		if (target.CodeMirror) {
 			codeMirror(target);
-		} else if (target.hasAttribute("data-uri")) {
+		} else if (target.classList.has('monaco-editor')) {
 			monacoEditor(target);
 		} else {
 			ace(target);

--- a/source/unsafe-messenger.js
+++ b/source/unsafe-messenger.js
@@ -6,11 +6,10 @@
 export default function unsafeMessenger() {
 	document.body.addEventListener('gt:get', listener);
 
-	// Add a new condition to check for the existence of the monaco object
 	function listener({target}) {
 		if (target.CodeMirror) {
 			codeMirror(target);
-		} else if (monaco) {
+		} else if (target.hasAttribute("data-uri")) {
 			monacoEditor(target);
 		} else {
 			ace(target);
@@ -77,17 +76,16 @@ export default function unsafeMessenger() {
 	}
 
 	function monacoEditor(target) {
-		const editor = monaco.editor.getModels()[0];
+		const data_uri = target.getAttribute("data-uri");
+		const editor = monaco.editor.getModels(data_uri)[0];
 		let currentValue = editor.getValue();
 		sendBack(target, currentValue);
+		const throttledSend = throttle(50, sendBack);
 
 		editor.onDidChangeContent((e) => {
-			// Check if the change was made by the user
 			if (e.isUserChange) {
-				// Check if the current value is different from the previous value
 				if (currentValue !== editor.getValue()) {
-					currentValue = editor.getValue();
-					throttle(50, sendBack)(target, currentValue);
+					throttledSend(target, editor.getValue());
 				}
 			}
 		});

--- a/source/unsafe-messenger.js
+++ b/source/unsafe-messenger.js
@@ -9,7 +9,7 @@ export default function unsafeMessenger() {
 	function listener({target}) {
 		if (target.CodeMirror) {
 			codeMirror(target);
-		} else if (target.classList.has('monaco-editor')) {
+		} else if (target.classList.contains('monaco-editor')) {
 			monacoEditor(target);
 		} else {
 			ace(target);
@@ -77,20 +77,17 @@ export default function unsafeMessenger() {
 	}
 
 	function monacoEditor(target) {
-		const data_uri = target.getAttribute("data-uri");
-		const editor = monaco.editor.getModel(data_uri);
-		let currentValue = editor.getValue();
+		const editor = globalThis.monaco.editor.getModel(target.dataset.uri);
+		const currentValue = editor.getValue();
 		sendBack(target, currentValue);
 		const throttledSend = throttle(50, sendBack);
 
-		editor.onDidChangeContent((e) => {
-			if (e.isUserChange) {
-				if (currentValue !== editor.getValue()) {
-					throttledSend(target, editor.getValue());
-				}
+		editor.onDidChangeContent(event => {
+			if (event.isUserChange && currentValue !== editor.getValue()) {
+				throttledSend(target, editor.getValue());
 			}
 		});
-	
+
 		target.addEventListener('gt:transfer', () => {
 			editor.setValue(target.getAttribute('gt-value'));
 		});
@@ -102,7 +99,6 @@ export default function unsafeMessenger() {
 			}
 		});
 	}
-	
 }
 
 // eslint-disable-next-line no-unused-expressions


### PR DESCRIPTION
This pull request adds support for the Monaco Editor. This resolves issue #140, which requested the ability to use GhostText with the Monaco Editor.

The changes include a new condition in the `unsafe-messenger.js` file that checks for the existence of the `monaco` object, and a new function `monacoEditor(target)` that handles the events and value transfer for the Monaco Editor.

This has been tested and confirmed to work with the Monaco Editor, and should not affect the existing support for CodeMirror and Ace.

Here's a demo of the update:

https://user-images.githubusercontent.com/12979345/214165120-d559ea7e-8ebd-4083-9f0e-a3fbdcbc3bab.mp4

