### PR TITLE
Add notification and focus options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules
 yarn.lock
 distribution
 .cache
+.yarn/cache
 .parcel-cache
 LocalOverrides.xcconfig

--- a/source/background.js
+++ b/source/background.js
@@ -62,7 +62,7 @@ function handlePortListenerErrors(listener) {
 
 chrome.runtime.onConnect.addListener(handlePortListenerErrors(async port => {
 	console.assert(port.name === 'new-field');
-	const {serverPort, focusOnDisconnect} = await optionsStorage.getAll();
+	const {serverPort, notifyOnConnect, focusOnDisconnect} = await optionsStorage.getAll();
 	const response = await fetch(`http://localhost:${serverPort}`);
 	const {ProtocolVersion, WebSocketPort} = await response.json();
 	if (ProtocolVersion !== 1) {

--- a/source/background.js
+++ b/source/background.js
@@ -62,8 +62,8 @@ function handlePortListenerErrors(listener) {
 
 chrome.runtime.onConnect.addListener(handlePortListenerErrors(async port => {
 	console.assert(port.name === 'new-field');
-	const {serverPort, notifyOnConnect, focusOnDisconnect} = await optionsStorage.getAll();
-	const response = await fetch(`http://localhost:${serverPort}`);
+	const options = await optionsStorage.getAll();
+	const response = await fetch(`http://localhost:${options.serverPort}`);
 	const {ProtocolVersion, WebSocketPort} = await response.json();
 	if (ProtocolVersion !== 1) {
 		throw new Error('Incompatible protocol version');

--- a/source/background.js
+++ b/source/background.js
@@ -62,7 +62,7 @@ function handlePortListenerErrors(listener) {
 
 chrome.runtime.onConnect.addListener(handlePortListenerErrors(async port => {
 	console.assert(port.name === 'new-field');
-	const {serverPort} = await optionsStorage.getAll();
+	const {serverPort, focusOnDisconnect} = await optionsStorage.getAll();
 	const response = await fetch(`http://localhost:${serverPort}`);
 	const {ProtocolVersion, WebSocketPort} = await response.json();
 	if (ProtocolVersion !== 1) {

--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -5,7 +5,7 @@ import optionsStorage from './options-storage.js';
 const knownElements = new Map();
 const activeFields = new Set();
 const eventOptions = {bubbles: true};
-const extOptions = optionsStorage.getAll();
+const optionsPromise = optionsStorage.getAll();
 
 let isWaitingForActivation = false;
 const startTimeout = 15_000;
@@ -120,7 +120,7 @@ class GhostTextField {
 				this.deactivate(false);
 				updateCount();
 			} else if (message.ready) {
-				const options = await extOptions;
+				const options = await optionsPromise;
 				if (options.notifyOnConnect) {
 					notify('log', 'Connected! You can switch to your editor');
 				}
@@ -201,7 +201,7 @@ class GhostTextField {
 		this.field.removeEventListener('input', this.send);
 		this.field.dataset.gtField = '';
 
-		const options = await extOptions;
+		const options = await optionsPromise;
 		if (options.focusOnDisconnect) {
 			chrome.runtime.sendMessage({
 				code: 'focus-tab',
@@ -236,7 +236,7 @@ async function updateCount() {
 	});
 
 	if (activeFields.size === 0) {
-		const options = await extOptions;
+		const options = await optionsPromise;
 		if (options.notifyOnConnect) {
 			notify('log', 'Disconnected! \n <a href="https://github.com/fregante/GhostText/issues" target="_blank">Report issues</a>');
 		}

--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -1,9 +1,11 @@
 import GThumane from './humane-ghosttext.js';
 import unsafeMessenger from './unsafe-messenger.js';
+import optionsStorage from './options-storage.js';
 
 const knownElements = new Map();
 const activeFields = new Set();
 const eventOptions = {bubbles: true};
+const extOptions = optionsStorage.getAll();
 
 let isWaitingForActivation = false;
 const startTimeout = 15_000;
@@ -184,7 +186,7 @@ class GhostTextField {
 		}
 	}
 
-	deactivate(wasSuccessful = true) {
+	async deactivate(wasSuccessful = true) {
 		if (this.state === 'inactive') {
 			return;
 		}
@@ -196,9 +198,12 @@ class GhostTextField {
 		this.field.removeEventListener('input', this.send);
 		this.field.dataset.gtField = '';
 
-		chrome.runtime.sendMessage({
-			code: 'focus-tab',
-		});
+		const options = await extOptions;
+		if (options.focusOnDisconnect) {
+			chrome.runtime.sendMessage({
+				code: 'focus-tab',
+			});
+		}
 
 		if (wasSuccessful) {
 			updateCount();

--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -113,14 +113,17 @@ class GhostTextField {
 		this.field.dataset.gtField = 'loading';
 
 		this.port = chrome.runtime.connect({name: 'new-field'});
-		this.port.onMessage.addListener(message => {
+		this.port.onMessage.addListener(async message => {
 			if (message.message) {
 				this.receive({data: message.message});
 			} else if (message.close) {
 				this.deactivate(false);
 				updateCount();
 			} else if (message.ready) {
-				notify('log', 'Connected! You can switch to your editor');
+				const options = await extOptions;
+				if (options.notifyOnConnect) {
+					notify('log', 'Connected! You can switch to your editor');
+				}
 
 				this.field.addEventListener('input', this.send);
 				this.field.dataset.gtField = 'enabled';
@@ -226,14 +229,17 @@ class GhostTextField {
 	}
 }
 
-function updateCount() {
+async function updateCount() {
 	chrome.runtime.sendMessage({
 		code: 'connection-count',
 		count: activeFields.size,
 	});
 
 	if (activeFields.size === 0) {
-		notify('log', 'Disconnected! \n <a href="https://github.com/fregante/GhostText/issues" target="_blank">Report issues</a>');
+		const options = await extOptions;
+		if (options.notifyOnConnect) {
+			notify('log', 'Disconnected! \n <a href="https://github.com/fregante/GhostText/issues" target="_blank">Report issues</a>');
+		}
 	}
 }
 

--- a/source/options-storage.js
+++ b/source/options-storage.js
@@ -3,6 +3,7 @@ import OptionsSync from 'webext-options-sync';
 const optionsStorage = new OptionsSync({
 	defaults: {
 		serverPort: 4001,
+		notifyOnConnect: true,
 	},
 });
 

--- a/source/options-storage.js
+++ b/source/options-storage.js
@@ -4,6 +4,7 @@ const optionsStorage = new OptionsSync({
 	defaults: {
 		serverPort: 4001,
 		notifyOnConnect: true,
+		focusOnDisconnect: true,
 	},
 });
 

--- a/source/options.css
+++ b/source/options.css
@@ -1,4 +1,14 @@
 .field {
 	display: flex;
-	align-items: start;
+	align-items: baseline;
+	gap: 0.7em
+}
+
+[type='checkbox'] {
+	margin: 0;
+	align-self: start;
+}
+
+#serverPort {
+	width: 7em;
 }

--- a/source/options.css
+++ b/source/options.css
@@ -1,3 +1,4 @@
 .field {
+	display: flex;
 	align-items: start;
 }

--- a/source/options.css
+++ b/source/options.css
@@ -1,0 +1,3 @@
+.field {
+	align-items: start;
+}

--- a/source/options.html
+++ b/source/options.html
@@ -44,9 +44,7 @@
 		/>
 		<label for="focusOnDisconnect">
 			Focus browser's tab when text editor is disconnected
-			<br/>
 			(some OS bring browser to the foreground,
-			<br/>
 			others 'flash' browser in the taskbar)
 		</label>
 	</div>

--- a/source/options.html
+++ b/source/options.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <meta charset="UTF-8" />
 <title>GhostText options</title>
-<link rel="stylesheet" href="npm:webext-base-css">
-<link rel="stylesheet" href="options.css">
+<style>
+	@import "npm:webext-base-css";
+	@import "./options.css";
+</style>
 <form id="options-form">
 	<label for="serverPort">
 		Server Port

--- a/source/options.html
+++ b/source/options.html
@@ -6,22 +6,23 @@
 	@import './options.css';
 </style>
 <form id="options-form">
-	<label for="serverPort">
-		Server Port
-	</label>
-	<input
-		name="serverPort"
-		id="serverPort"
-		type="number"
-		min="1"
-		max="65536"
-		step="1"
-		placeholder="4001"
-		value="4001"
-		required
-	/>
-	<br>
-	<div class="field">
+	<p class="field">
+		<label for="serverPort">
+			Server Port
+		</label>
+		<input
+			name="serverPort"
+			id="serverPort"
+			type="number"
+			min="1"
+			max="65536"
+			step="1"
+			placeholder="4001"
+			value="4001"
+			required
+		/>
+	</p>
+	<p class="field">
 		<input
 			name="notifyOnConnect"
 			id="notifyOnConnect"
@@ -31,9 +32,8 @@
 		<label for="notifyOnConnect">
 			Display notifications when connected and disconnected
 		</label>
-	</div>
-	<br>
-	<div class="field">
+	</p>
+	<p class="field">
 		<input
 			name="focusOnDisconnect"
 			id="focusOnDisconnect"
@@ -41,12 +41,13 @@
 			checked
 		/>
 		<label for="focusOnDisconnect">
-			Bring the focus back to the browser when disconnected (some OS bring the browser to the foreground, others 'flash' the browser icon in the taskbar)
+			Bring the focus back to the browser when disconnected. <br>
+			some OS bring the browser to the foreground, others 'flash' the browser icon in the taskbar.
 		</label>
-	</div>
+	</p>
 </form>
-<p>You can find information on how GhostText works and how to troubleshoot any issues on <a href="https://github.com/fregante/GhostText">its repo</a>.</p>
 <hr>
+<p>You can find information on how GhostText works and how to troubleshoot any issues on <a href="https://github.com/fregante/GhostText">its repo</a>.</p>
 <p>If you find this useful, consider supporting its development by <a href="https://github.com/sponsors/fregante">donating or sponsoring me on GitHub</a>.</p>
 <p>Made with 🍕 by <a href="https://fregante.com">fregante</a>.</p>
 <script type="module" src="options.js"></script>

--- a/source/options.html
+++ b/source/options.html
@@ -17,6 +17,16 @@
 		value="4001"
 		required
 	/>
+	<br>
+	<input
+		name="notifyOnConnect"
+		id="notifyOnConnect"
+		type="checkbox"
+		value="notify"
+		checked=true
+	/>
+	<label for="notifyOnConnect">
+		Display notification popup on connect/disconnect with the text editor
 	</label>
 </form>
 <p>You can find information on how GhostText works and how to troubleshoot any issues on <a href="https://github.com/fregante/GhostText">its repo</a>.</p>

--- a/source/options.html
+++ b/source/options.html
@@ -2,6 +2,7 @@
 <meta charset="UTF-8" />
 <title>GhostText options</title>
 <link rel="stylesheet" href="npm:webext-base-css">
+<link rel="stylesheet" href="options.css">
 <form id="options-form">
 	<label for="serverPort">
 		Server Port
@@ -18,31 +19,35 @@
 		required
 	/>
 	<br>
-	<input
-		name="notifyOnConnect"
-		id="notifyOnConnect"
-		type="checkbox"
-		value="notify"
-		checked=true
-	/>
-	<label for="notifyOnConnect">
-		Display notification popup on connect/disconnect with the text editor
-	</label>
+	<div class="field" style="display: flex">
+		<input
+			name="notifyOnConnect"
+			id="notifyOnConnect"
+			type="checkbox"
+			value="notify"
+			checked=true
+		/>
+		<label for="notifyOnConnect">
+			Display notification popup on connect/disconnect with the text editor
+		</label>
+	</div>
 	<br>
-	<input
-		name="focusOnDisconnect"
-		id="focusOnDisconnect"
-		type="checkbox"
-		value="focus"
-		checked=true
-	/>
-	<label for="focusOnDisconnect">
-		Focus browser's tab when text editor is disconnected
-		<br/>
-		(some OS bring browser to the foreground,
-		<br/>
-		others 'flash' browser in the taskbar)
-	</label>
+	<div class="field" style="display: flex">
+		<input
+			name="focusOnDisconnect"
+			id="focusOnDisconnect"
+			type="checkbox"
+			value="focus"
+			checked=true
+		/>
+		<label for="focusOnDisconnect">
+			Focus browser's tab when text editor is disconnected
+			<br/>
+			(some OS bring browser to the foreground,
+			<br/>
+			others 'flash' browser in the taskbar)
+		</label>
+	</div>
 </form>
 <p>You can find information on how GhostText works and how to troubleshoot any issues on <a href="https://github.com/fregante/GhostText">its repo</a>.</p>
 <hr>

--- a/source/options.html
+++ b/source/options.html
@@ -2,8 +2,8 @@
 <meta charset="UTF-8" />
 <title>GhostText options</title>
 <style>
-	@import "npm:webext-base-css";
-	@import "./options.css";
+	@import 'npm:webext-base-css';
+	@import './options.css';
 </style>
 <form id="options-form">
 	<label for="serverPort">
@@ -21,31 +21,27 @@
 		required
 	/>
 	<br>
-	<div class="field" style="display: flex">
+	<div class="field">
 		<input
 			name="notifyOnConnect"
 			id="notifyOnConnect"
 			type="checkbox"
-			value="notify"
-			checked=true
+			checked
 		/>
 		<label for="notifyOnConnect">
-			Display notification popup on connect/disconnect with the text editor
+			Display notifications when connected and disconnected
 		</label>
 	</div>
 	<br>
-	<div class="field" style="display: flex">
+	<div class="field">
 		<input
 			name="focusOnDisconnect"
 			id="focusOnDisconnect"
 			type="checkbox"
-			value="focus"
-			checked=true
+			checked
 		/>
 		<label for="focusOnDisconnect">
-			Focus browser's tab when text editor is disconnected
-			(some OS bring browser to the foreground,
-			others 'flash' browser in the taskbar)
+			Bring the focus back to the browser when disconnected (some OS bring the browser to the foreground, others 'flash' the browser icon in the taskbar)
 		</label>
 	</div>
 </form>

--- a/source/options.html
+++ b/source/options.html
@@ -3,18 +3,20 @@
 <title>GhostText options</title>
 <link rel="stylesheet" href="npm:webext-base-css">
 <form id="options-form">
-	<label>
+	<label for="serverPort">
 		Server Port
-		<input
-			name="serverPort"
-			type="number"
-			min="1"
-			max="65536"
-			step="1"
-			placeholder="4001"
-			value="4001"
-			required
-		/>
+	</label>
+	<input
+		name="serverPort"
+		id="serverPort"
+		type="number"
+		min="1"
+		max="65536"
+		step="1"
+		placeholder="4001"
+		value="4001"
+		required
+	/>
 	</label>
 </form>
 <p>You can find information on how GhostText works and how to troubleshoot any issues on <a href="https://github.com/fregante/GhostText">its repo</a>.</p>

--- a/source/options.html
+++ b/source/options.html
@@ -28,6 +28,21 @@
 	<label for="notifyOnConnect">
 		Display notification popup on connect/disconnect with the text editor
 	</label>
+	<br>
+	<input
+		name="focusOnDisconnect"
+		id="focusOnDisconnect"
+		type="checkbox"
+		value="focus"
+		checked=true
+	/>
+	<label for="focusOnDisconnect">
+		Focus browser's tab when text editor is disconnected
+		<br/>
+		(some OS bring browser to the foreground,
+		<br/>
+		others 'flash' browser in the taskbar)
+	</label>
 </form>
 <p>You can find information on how GhostText works and how to troubleshoot any issues on <a href="https://github.com/fregante/GhostText">its repo</a>.</p>
 <hr>


### PR DESCRIPTION
Adds two options:
  1. Show notification messages on (dis)connect (on by default)
  2. Focus browser tab on disconnect (also on by default)


- closes https://github.com/fregante/GhostText/issues/243
- closes https://github.com/fregante/GhostText/issues/109