### PR TITLE
Drop unused blur events

### DIFF
--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -18,7 +18,6 @@ class ContentEditableWrapper {
 		this.addEventListener = element.addEventListener.bind(element);
 		this.removeEventListener = element.removeEventListener.bind(element);
 		this.dispatchEvent = element.dispatchEvent.bind(element);
-		this.blur = element.blur.bind(element);
 	}
 
 	get value() {
@@ -42,10 +41,6 @@ class AdvancedTextWrapper {
 				bubbles: true,
 			}),
 		);
-	}
-
-	blur() {
-		this.el.dispatchEvent(new CustomEvent('gt:blur'));
 	}
 
 	addEventListener(type, callback) {

--- a/source/unsafe-messenger.js
+++ b/source/unsafe-messenger.js
@@ -48,9 +48,6 @@ export default function unsafeMessenger() {
 		target.addEventListener('gt:transfer', () => {
 			editor.setValue(target.getAttribute('gt-value'));
 		});
-		target.addEventListener('gt:blur', () => {
-			editor.getInputField().blur();
-		});
 	}
 
 	function ace(target) {
@@ -71,9 +68,6 @@ export default function unsafeMessenger() {
 				session.setValue(target.getAttribute('gt-value'));
 			}
 		});
-		target.addEventListener('gt:blur', () => {
-			editor.blur();
-		});
 	}
 
 	function monacoEditor(target) {
@@ -88,9 +82,6 @@ export default function unsafeMessenger() {
 
 		target.addEventListener('gt:transfer', () => {
 			editor.setValue(target.getAttribute('gt-value'));
-		});
-		target.addEventListener('gt:blur', () => {
-			target.ownerDocument.activeElement.blur();
 		});
 	}
 }


### PR DESCRIPTION
I can't find why they were ever implemented. In the modern version I just recreated the API but never actually used it.

