### PR TITLE
Update Protocol to allow WebSocketPort/HTTP port reuse

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -26,7 +26,7 @@ The JSON payload is an object with the following properties:
 | Property          | Type   | Description                          |
 | ----------------- | ------ | ------------------------------------ |
 | `ProtocolVersion` | Number | The protocol version                 |
-| `WebSocketPort`   | Number | The port for the listening WebSocket |
+| `WebSocketPort`   | Number | The port for the listening WebSocket. This ideally is the same configured HTTP port (default 4001) but it doesn’t have to be. |
 
 #### Example
 


### PR DESCRIPTION
In https://github.com/fregante/GhostText-for-VSCode/commit/cb5ef60d469cb293cc061994c16c3580ad1e63d7 I verified that:

- The editor doesn't have to create a new WebSocket server for connection
- The WebSocket can share the same port as the HTTP server (default 4001)

The previous setup was carried over from the original proof of concept and never challenged.