### PR TITLE
Add shortcut to disconnect fields

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -2,13 +2,6 @@ import browser from 'webextension-polyfill';
 import oneEvent from 'one-event';
 import optionsStorage from './options-storage.js';
 
-function inCurrentTab(callback) {
-	chrome.tabs.query({
-		active: true,
-		currentWindow: true,
-	}, tabs => callback(tabs[0]));
-}
-
 function handleClose(info, tab) {
 	chrome.tabs.executeScript(tab.id, {
 		code: 'stopGT()',
@@ -140,9 +133,16 @@ function init() {
 		contexts: ['browser_action'],
 		onclick: handleClose,
 	});
-	chrome.commands.onCommand.addListener(command => {
+	chrome.commands.onCommand.addListener((command, tab) => {
+		if (!tab?.id) {
+			console.warn('No tab information was received for command', {command, tab});
+			return;
+		}
+
 		if (command === 'open') {
-			inCurrentTab(handleAction);
+			handleAction(tab);
+		} else if (command === 'close') {
+			handleClose({}, tab);
 		}
 	});
 

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -47,6 +47,9 @@
 				"default": "Ctrl+Shift+K",
 				"linux": "Ctrl+Shift+H"
 			}
+		},
+		"close": {
+			"description": "Disconnect from GhostText"
 		}
 	},
 	"content_scripts": [


### PR DESCRIPTION
- For https://github.com/fregante/GhostText/pull/245#issuecomment-1468735139

There's no default shortcut set because the other shortcut will also be dropped soon:

- #241 

The duplicate activation shortcut will likely dropped in the future. It's there because of an old browser bug (hopefully fixed now)

<img width="481" alt="Screenshot" src="https://user-images.githubusercontent.com/1402241/225558095-19a3fda7-951b-44c9-bf68-39d0508508ea.png">

