### PR TITLE
Improve TiddlyWiki support

### DIFF
--- a/source/ghost-text.js
+++ b/source/ghost-text.js
@@ -122,7 +122,7 @@ class GhostTextField {
 
 		this.field.dataset.gtField = 'loading';
 
-		this.port = browser.runtime.connect({name: 'new-field'});
+		this.port = chrome.runtime.connect({name: 'new-field'});
 		this.port.onMessage.addListener(async packet => {
 			if (packet.message) {
 				this.receive({data: packet.message});
@@ -213,7 +213,7 @@ class GhostTextField {
 
 		const options = await optionsPromise;
 		if (options.focusOnDisconnect) {
-			browser.runtime.sendMessage({
+			chrome.runtime.sendMessage({
 				code: 'focus-tab',
 			});
 		}
@@ -240,7 +240,7 @@ class GhostTextField {
 }
 
 async function updateCount() {
-	browser.runtime.sendMessage({
+	chrome.runtime.sendMessage({
 		code: 'connection-count',
 		count: activeFields.size,
 	});
@@ -258,7 +258,7 @@ function injectCSS(root) {
 	// Injects ghost-text.css into iframe document roots
 	if (!registeredFrames.has(root)) {
 		const cssLink = root.createElement("link")
-		cssLink.href = browser.runtime.getURL('ghost-text.css');
+		cssLink.href = chrome.runtime.getURL('ghost-text.css');
 		cssLink .rel = "stylesheet";
 		cssLink.type = "text/css";
 		registeredFrames.add(root);


### PR DESCRIPTION
This fixes #236.
There seems to still be a hangup in tiddlywiki that requires a user to click twice on the `<textarea>` immediately after load, but this doesn't seem to be persisent, so I'm not all too worried about it.
I'm not very familiar with the browser extension APIs, so I'm not sure if running code inside iframes is supposed to be done differently, but this worked in both Firefox 111.0.1 and Chromium 112.0.5615.49 (with vim-GhostText).