### PR TITLE
Improve support for frames in Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"@parcel/config-webextension": "^2.8.3",
 				"dot-json": "^1.2.2",
 				"parcel": "^2.8.3",
+				"webext-domain-permission-toggle": "^4.0.1",
 				"xo": "^0.53.1"
 			},
 			"engines": {
@@ -7344,6 +7345,18 @@
 			"integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
 			"dev": true
 		},
+		"node_modules/webext-additional-permissions": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/webext-additional-permissions/-/webext-additional-permissions-2.4.0.tgz",
+			"integrity": "sha512-u4g2taAPJZiwVftQek6pd7LfV6zuhMRRpsy/6SyAn2KBylbXKpY8KVVX7tOpJuuS6DMTLL5Fr49+p5e3SIX9YA==",
+			"dev": true,
+			"dependencies": {
+				"webext-patterns": "^1.3.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
+		},
 		"node_modules/webext-base-css": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/webext-base-css/-/webext-base-css-1.4.3.tgz",
@@ -7352,10 +7365,40 @@
 				"url": "https://github.com/sponsors/fregante"
 			}
 		},
+		"node_modules/webext-content-scripts": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/webext-content-scripts/-/webext-content-scripts-2.5.3.tgz",
+			"integrity": "sha512-K1DCmUG0nQnyT8GUvkCwRCLHDXB/sYDw5WvDDejT81iT7r8E8bRIAOAlwOVU3oKgdJ0TvBXGnATJ2Gj2Lgnzsg==",
+			"dev": true,
+			"dependencies": {
+				"webext-patterns": "^1.3.0",
+				"webext-polyfill-kinda": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
+		},
 		"node_modules/webext-detect-page": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-4.1.0.tgz",
+			"integrity": "sha512-GFL+0XLO18/1d7425E2Yt3o1RfggjIrwrKskfdBbQBx8jmH9WBKOTAfI3XCROyECIvYoG1T53I0qPMN87bzHuw=="
+		},
+		"node_modules/webext-domain-permission-toggle": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-4.0.1.tgz",
-			"integrity": "sha512-Y9Skw6/Uj0dGwOIidc1XqZ3neEbmuuT4BlkL/J4JHAo6fVznHIZq6/MWDsPGOA/jnNowiSXtHHh4S/TOxbl6bQ=="
+			"resolved": "https://registry.npmjs.org/webext-domain-permission-toggle/-/webext-domain-permission-toggle-4.0.1.tgz",
+			"integrity": "sha512-P9ECzrLWMbd6nfz4UTFqafHedKpS7x3zdRjQRUYDRVKAbZGZ0ivxG7qJBnx+Q2+2r5TuQBdcLFBNUhIaSDBc+w==",
+			"dev": true,
+			"dependencies": {
+				"webext-additional-permissions": "^2.4.0",
+				"webext-content-scripts": "^2.5.3",
+				"webext-detect-page": "^4.1.0",
+				"webext-patterns": "^1.3.0",
+				"webext-polyfill-kinda": "^1.0.2",
+				"webext-tools": "^1.1.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
 		},
 		"node_modules/webext-options-sync": {
 			"version": "4.0.1",
@@ -7372,10 +7415,48 @@
 				"url": "https://github.com/sponsors/fregante"
 			}
 		},
+		"node_modules/webext-patterns": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/webext-patterns/-/webext-patterns-1.3.0.tgz",
+			"integrity": "sha512-X9HMnic9ZtvSFKi2cdh0l+sxyj7f9oLedaa2JfxjnyEqGBz8OJjaHQ40jmraX1DJLTHOpqr+rCz1r3MW2+doUg==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^5.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
+		},
+		"node_modules/webext-patterns/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/webext-polyfill-kinda": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.0.tgz",
-			"integrity": "sha512-Py/d3w/bC0KntuO60ePSWHsdrebZ3uYBLeFUjyPkDV3yTEQib0MRFvPh57t8XjImu4ylBoEAsFjzh/r22UtxMw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/webext-polyfill-kinda/-/webext-polyfill-kinda-1.0.2.tgz",
+			"integrity": "sha512-rqQUKeBTOicej0tjDJWDQlOTnDcm9yYJTzgI+7rMdyYV4QHmYMRm+yjkcVgECkg/Wu9MboZ4lYeBPdp1Ep9WgQ==",
+			"funding": {
+				"url": "https://github.com/sponsors/fregante"
+			}
+		},
+		"node_modules/webext-tools": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/webext-tools/-/webext-tools-1.1.3.tgz",
+			"integrity": "sha512-OBEFMzCWSqFoY9Uwu6bKHcYmsjvSoYq99wh31cVvaXqsYk6Iz3rBCPFCMoMHnvieKj+GYrv6Z0ssZVOshLvDWg==",
+			"dev": true,
+			"dependencies": {
+				"webext-content-scripts": "^2.5.1",
+				"webext-detect-page": "^4.0.1",
+				"webext-polyfill-kinda": "^1.0.0"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/fregante"
 			}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"@parcel/config-webextension": "^2.8.3",
 		"dot-json": "^1.2.2",
 		"parcel": "^2.8.3",
+		"webext-domain-permission-toggle": "^4.0.1",
 		"xo": "^0.53.1"
 	},
 	"engines": {

--- a/source/background.js
+++ b/source/background.js
@@ -1,6 +1,11 @@
+import addDomainPermissionToggle from 'webext-domain-permission-toggle';
 import browser from 'webextension-polyfill';
 import oneEvent from 'one-event';
 import optionsStorage from './options-storage.js';
+
+if (navigator.userAgent.includes('Firefox/')) {
+	addDomainPermissionToggle();
+}
 
 function stopGT(tab) {
 	chrome.tabs.executeScript(tab.id, {

--- a/source/background.js
+++ b/source/background.js
@@ -3,6 +3,9 @@ import browser from 'webextension-polyfill';
 import oneEvent from 'one-event';
 import optionsStorage from './options-storage.js';
 
+// Firefox hates iframes on activeTab
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1653408
+// https://github.com/fregante/GhostText/pull/285
 if (navigator.userAgent.includes('Firefox/')) {
 	// eslint-disable-next-line unicorn/prefer-top-level-await -- I specifically want to not stop the extension in case of errors
 	(async () => {

--- a/source/background.js
+++ b/source/background.js
@@ -4,7 +4,12 @@ import oneEvent from 'one-event';
 import optionsStorage from './options-storage.js';
 
 if (navigator.userAgent.includes('Firefox/')) {
-	addDomainPermissionToggle();
+	// eslint-disable-next-line unicorn/prefer-top-level-await -- I specifically want to not stop the extension in case of errors
+	(async () => {
+		addDomainPermissionToggle({
+			title: 'Grant access to iframes',
+		});
+	})();
 }
 
 function stopGT(tab) {

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -19,6 +19,9 @@
 		"http://localhost/",
 		"storage"
 	],
+	"optional_permissions": [
+		"*://*/*"
+	],
 	"applications": {
 		"gecko": {
 			"id": "ghosttext@bfred.it",


### PR DESCRIPTION
- Fixes #236 
- Follows https://github.com/fregante/GhostText/pull/284
- Works around https://bugzilla.mozilla.org/show_bug.cgi?id=1653408
- Related: https://github.com/pixiebrix/pixiebrix-extension/issues/5035

I had initially added this piece of code, but it makes GhostText more annoying, unnecessarily:

```diff
- async function handleAction({id}) {
+ async function handleAction({id, url}) {
+ 	await browser.permissions.request({
+ 		origins: [new URL(url).origin + '/*']
+ 	});
```